### PR TITLE
Sanitize room name

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,6 +414,13 @@
           this.$refs.navbar.logIn();
           return;
         }
+        // Sanitize room name
+        this.room.name = this.room.name
+            .trim()
+            .toLowerCase()
+            .replace(/\s/g, "-") // whitespace
+            .replace(/[^\p{L}-]/gu, ''); // not (dash or letter in any language)
+
         const room = await getRoom(this.room);
         if (room) {
           this.room = room;


### PR DESCRIPTION
- Lowercases and trims leading and trailing whitespace, replaces inner whitespaces with dashes, and strips all other non-letters. This allows foreign language room names without allowing digits, punctuation marks, emojis, or other special chars.
- I'm pretty sure this makes the query strings always work (since we're excluding &,+,=)