### PR TITLE
Refactor common updateRoom pattern

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -275,21 +275,36 @@
         }
       },
       async createClue(word) {
-        const update = {
-          [`currentRound.clues.${this.player.name}`]: {
-            word,
-            hint: this.player.hint,
-            contact: '',
-            contactedWord: '',
-          },
-        };
-        await updateRoom(this.room, update);
+        if (word == this.room.currentRound.word) {
+          swal('Victory!', `${this.player.name} correctly guessed the word "${this.room.currentRound.word}"`);
+          await this.nextRound();
+        } else {
+          const update = {
+            [`currentRound.clues.${this.player.name}`]: {
+              word,
+              hint: this.player.hint,
+              contact: '',
+              contactedWord: '',
+            },
+          };
+          await updateRoom(this.room, update);
+        }
       },
       async withdrawClue() {
         delete this.room.currentRound.clues[this.player.name];
         await updateRoom(this.room, {
           'currentRound.clues': this.room.currentRound.clues,
         });
+      },
+      async nextLetter() {
+        this.room.currentRound.revealed++;
+        if (this.room.currentRound.revealed >= this.room.currentRound.word.length) {
+          swal('Victory', `The word is "${this.room.currentRound.word}"`);
+          await this.nextRound();
+        } else {
+          this.room.currentRound.clues = {};
+          await updateRoom(this.room, { currentRound: this.room.currentRound });
+        }
       },
       // Wrapper, since Submit onEnter expects a function.
       contact(cluer) {

--- a/index.html
+++ b/index.html
@@ -142,13 +142,13 @@
             >
               <div class="mx-1" v-if="isMod">
                 <span class="select is-small">
-                  <select v-model="room.public" :disabled="!user.supporter" @change="save('public')">
+                  <select v-model="room.public" :disabled="!user.supporter" @change="saveRoom('public')">
                     <option v-bind:value="true">Public</option>
                     <option v-bind:value="false">Private</option>
                   </select>
                 </span>
                 <span class="select is-small">
-                  <select v-model="room.roundsInGame" :disabled="!user.supporter" @change="save('roundsInGame')">
+                  <select v-model="room.roundsInGame" :disabled="!user.supporter" @change="saveRoom('roundsInGame')">
                     <option v-bind:value="13">13 rounds</option>
                     <option v-bind:value="'Unlimited'">&infin; rounds</option>
                   </select>
@@ -204,7 +204,7 @@
             <span v-if="isMod" class="field is-grouped is-grouped-multiline mx-3 my-1">
               <div class="control" v-for="category in this.CATEGORY_ORDER">
                 <label class="capitalize checkbox">
-                  <input type="checkbox" v-model="room.categories[category]" @change="save('categories')" />
+                  <input type="checkbox" v-model="room.categories[category]" @change="saveRoom('categories')" />
                   {{ category }}
                 </label>
               </div>
@@ -231,7 +231,9 @@
               </div>
               <div class="control">
                 <button v-if="wordsSaved" class="button is-small" disabled>Saved</button>
-                <button v-else class="button is-small" @click="wordsSaved = true; save('customWords');">Save</button>
+                <button v-else class="button is-small" @click="wordsSaved = true; saveRoom('customWords');">
+                  Save
+                </button>
               </div>
             </div>
           </div>
@@ -581,10 +583,10 @@
         this.room.playerData[this.player.name] = { email, supporter };
 
         if (this.room.players.includes(this.player.name)) {
-          await this.save('playerData');
+          await this.saveRoom('playerData');
         } else {
           this.room.players.push(this.player.name);
-          await this.save('playerData', 'players');
+          await this.saveRoom('playerData', 'players');
         }
       },
       goHome() {
@@ -595,7 +597,7 @@
         if (this.room.players.includes(name)) {
           const index = this.room.players.indexOf(name);
           this.room.players.splice(index, 1);
-          await this.save('players');
+          await this.saveRoom('players');
         }
       },
       async makeMod(name) {
@@ -603,7 +605,7 @@
         if (index >= 0) {
           // swap players[0] and players[index]
           [this.room.players[0], this.room.players[index]] = [this.room.players[index], this.room.players[0]];
-          await this.save('players');
+          await this.saveRoom('players');
         }
       },
       wordForWord(category) {
@@ -667,10 +669,10 @@
       },
       async toggleTimers() {
         this.room.timers.running = !this.room.timers.running;
-        await this.save('timers');
+        await this.saveRoom('timers');
       },
-      // sync any number of properties of this.room to firebase
-      async save(...props) {
+      // Sync any number of properties of this.room to firebase
+      async saveRoom(...props) {
         await updateRoom(this.room, Object.fromEntries(props.map((prop) => [prop, this.room[prop]])));
       },
       async shareRoom() {


### PR DESCRIPTION
No user-facing changes.

We frequently have a pattern of `updateRoom(this.room, { prop: this.room.prop }` when we want the user to see the change before it syncs to firebase. We have four different functions in `methods` that do this, and nothing else. I thought this was too repetitive, so I replaced them with a common `save()` method that takes in properties as string arguments.

I'm not really sure whether this utility function belongs in firebase-network.js or index.html

