### PR TITLE
Lower case input word

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@
     const custom = customWords.split(/\s/);
     const categories = { nouns, compounds, verbs, adjectives, custom };
     const words = categories[category];
-    return words[Math.floor(Math.random() * words.length)];
+    return words[Math.floor(Math.random() * words.length)].toLowerCase();
   }
 
   function nextWord(history, category = 'nouns', customWords = '') {


### PR DESCRIPTION
### Summary

Always lower case the word being guessed.

This solves an issue where custom user words with capitalization would be impossible to guess as a guesser and allows simple standardization for words for analytics. 