### PR TITLE
Bryant dev

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,11 +124,12 @@
       <br /><br />
       <h2 class="fancy">Open Rooms</h2>
       <template v-for="openRoom in allRooms">
-        <div v-bind:class="{ halfOpacity: isMuteOpenRoom(openRoom) }"><p>
-          <a @click="room.name = openRoom.name; enterRoom()"><b>{{ openRoom.name }}</b></a
-          >, with {{ openRoom.players.join(', ') }} ({{ moment(openRoom.lastUpdateTime).fromNow() }})
-        </p>
-      </div>
+        <div v-bind:class="{ halfOpacity: isMuteOpenRoom(openRoom) }">
+          <p>
+            <a @click="room.name = openRoom.name; enterRoom()"><b>{{ openRoom.name }}</b></a
+            >, with {{ openRoom.players.join(', ') }} ({{ moment(openRoom.lastUpdateTime).fromNow() }})
+          </p>
+        </div>
       </template>
     </div>
     <!-- In game -->
@@ -542,7 +543,7 @@
         const roomNameRe = new RegExp(this.room.name, 'i');
         for (const openRoom of this.allRooms) {
           if (openRoom.name.match(roomNameRe)) {
-            filtered.add(openRoom.name)
+            filtered.add(openRoom.name);
           }
         }
         return filtered;
@@ -752,7 +753,7 @@
       },
       // Returns a bool indicating if the provided Room object should be muted due to not matching the
       // currently entered Room field. Will always return false if no open rooms match the current room name.
-      isMuteOpenRoom: function(openRoom) {
+      isMuteOpenRoom: function (openRoom) {
         return this.filteredRoomNameSet.size != 0 && !this.filteredRoomNameSet.has(openRoom.name);
       },
       correct,


### PR DESCRIPTION
Add new visual muting of open rooms that do not match (via simple regex) the current value in the `Room` input on the welcome page.

Visual muting is done via setting each non-matching room to .5 transparency.
If the current value in the `Room` input does not match any current displayed open rooms, no open rooms will be muted.